### PR TITLE
Add RequestKYC parameter to support Pay n Play feature

### DIFF
--- a/Trustly/Api/signed.php
+++ b/Trustly/Api/signed.php
@@ -433,8 +433,8 @@ class Trustly_Api_Signed extends Trustly_Api {
 	 *		$nationalidentificationnumber should be considered read only information
 	 *		and will not be changable by end the enduser. Only valid in Sweden,
 	 *		the $nationalidentification number needs to be well formed.
-     *
-     * @param bool $requestKYC Flag to pass whether we request KYC check or not (Pay N Play feature)
+	 *
+	 * @param bool $requestKYC Flag to pass whether we request KYC check or not (Pay N Play feature)
 	 *
 	 * @return Trustly_Data_JSONRPCSignedResponse
 	 */
@@ -489,9 +489,9 @@ class Trustly_Api_Signed extends Trustly_Api {
 			if($unchangeablenationalidentificationnumber) {
 				$attributes['UnchangeableNationalIdentificationNumber'] = 1;
 			}
-            if(NULL !== $requestKYC) {
-                $attributes['requestKYC'] = $requestKYC;
-            }
+			if($requestKYC) {
+				$attributes['requestKYC'] = 1;
+			}
 
 			$request = new Trustly_Data_JSONRPCRequest('Deposit', $data, $attributes);
 			return $this->call($request);

--- a/Trustly/Api/signed.php
+++ b/Trustly/Api/signed.php
@@ -490,7 +490,7 @@ class Trustly_Api_Signed extends Trustly_Api {
 				$attributes['UnchangeableNationalIdentificationNumber'] = 1;
 			}
 			if($requestKYC) {
-				$attributes['requestKYC'] = 1;
+				$attributes['RequestKYC'] = 1;
 			}
 
 			$request = new Trustly_Data_JSONRPCRequest('Deposit', $data, $attributes);

--- a/Trustly/Api/signed.php
+++ b/Trustly/Api/signed.php
@@ -433,6 +433,8 @@ class Trustly_Api_Signed extends Trustly_Api {
 	 *		$nationalidentificationnumber should be considered read only information
 	 *		and will not be changable by end the enduser. Only valid in Sweden,
 	 *		the $nationalidentification number needs to be well formed.
+     *
+     * @param bool $requestKYC Flag to pass whether we request KYC check or not (Pay N Play feature)
 	 *
 	 * @return Trustly_Data_JSONRPCSignedResponse
 	 */
@@ -446,7 +448,7 @@ class Trustly_Api_Signed extends Trustly_Api {
 		$email=NULL, $shippingaddresscountry=NULL,
 		$shippingaddresspostalcode=NULL, $shippingaddresscity=NULL,
 		$shippingaddressline1=NULL, $shippingaddressline2=NULL,
-		$shippingaddress=NULL, $unchangeablenationalidentificationnumber=NULL) {
+		$shippingaddress=NULL, $unchangeablenationalidentificationnumber=NULL, $requestKYC=NULL) {
 
 			$data = array(
 				'NotificationURL' => $notificationurl,
@@ -487,6 +489,9 @@ class Trustly_Api_Signed extends Trustly_Api {
 			if($unchangeablenationalidentificationnumber) {
 				$attributes['UnchangeableNationalIdentificationNumber'] = 1;
 			}
+            if(NULL !== $requestKYC) {
+                $attributes['requestKYC'] = $requestKYC;
+            }
 
 			$request = new Trustly_Data_JSONRPCRequest('Deposit', $data, $attributes);
 			return $this->call($request);


### PR DESCRIPTION
Added additional flag "RequestKYC" which enables using Pay n Play feature, where user can start playing games instantly after his deposit.
More information:
**https://trustly.com/en/products/paynplay/**